### PR TITLE
Added the ability to scroll the date to a specified table view position.

### DIFF
--- a/TimesSquare/TSQCalendarView.h
+++ b/TimesSquare/TSQCalendarView.h
@@ -104,6 +104,16 @@
  */
 - (void)scrollToDate:(NSDate *)date animated:(BOOL)animated;
 
+
+
+/** Scrolls the receiver until the specified date is at the specified position in the view.
+
+@param date A date that identifies the month that will be visible.
+@param position A UITableViewScroll Position, determining the position of the date after scroll is finished.
+@param animated YES if you want to animate the change in position, NO if it should be immediate.
+*/
+- (void)scrollDate:(NSDate *)date toPosition:(UITableViewScrollPosition)position animated:(BOOL)animated;
+
 @end
 
 /** The methods in the `TSQCalendarViewDelegate` protocol allow the adopting delegate to either prevent a day from being selected or respond to it.

--- a/TimesSquare/TSQCalendarView.m
+++ b/TimesSquare/TSQCalendarView.m
@@ -162,6 +162,18 @@
   [self.tableView scrollToRowAtIndexPath:[NSIndexPath indexPathForRow:0 inSection:section] atScrollPosition:UITableViewScrollPositionTop animated:animated];
 }
 
+
+
+- (void)scrollDate:(NSDate *)date toPosition:(UITableViewScrollPosition)position animated:(BOOL)animated {
+    NSIndexPath *cellPath = [self indexPathForRowAtDate:date];
+
+    [self.tableView scrollToRowAtIndexPath:cellPath
+                          atScrollPosition:position
+                                  animated:animated];
+}
+
+
+
 - (TSQCalendarMonthHeaderCell *)makeHeaderCellWithIdentifier:(NSString *)identifier;
 {
     TSQCalendarMonthHeaderCell *cell = [[[self headerCellClass] alloc] initWithCalendar:self.calendar reuseIdentifier:identifier];


### PR DESCRIPTION
Hi,
We needed the ability to put today's (or any date) at the top of the scroll position, rather than just scroll to a month. We thought we'd share this back, if there are any concerns we have please let us know, but we added documentation and tidied it up - so hopefully all is good.